### PR TITLE
Don't run week-number module on the forum page

### DIFF
--- a/src/common/types/module.ts
+++ b/src/common/types/module.ts
@@ -11,6 +11,9 @@ export type Module = {
   name: string
   // Pages where the module should run (see @common/utils/pages.ts for a list of pages)
   pages: Page[]
+  // Pages where the module should not run
+  // This is only evaluated when `pages: [pages.all]`, otherwise it is ignored
+  excludePages?: Page[]
   // Function containing the module's logic
   run: () => void
 }

--- a/src/common/utils/pages.ts
+++ b/src/common/utils/pages.ts
@@ -39,6 +39,7 @@ export const pages = {
 
   // Pages not related to the user's team
   appDenominations: new Page('/Help/Rules/AppDenominations.aspx'),
+  forum: new Page('/Forum/'),
   series: new Page('/World/Series/'),
   transfers: new Page('/World/Transfers/'),
   transfersSearchResult: new Page('/World/Transfers/TransfersSearchResult.aspx'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,10 @@ if (isLoggedIn()) {
   logger.debug(`Current pathname: ${getCurrentPathname()}`)
 
   modules.forEach((module) => {
-    if (!module.pages.some((page) => page === pages.all || isPage(page))) return
+    const isAll = module.pages.includes(pages.all)
+    const matchesPage = isAll || module.pages.some((page) => isPage(page))
+    const isExcluded = isAll && module.excludePages?.some((page) => isPage(page))
+    if (!matchesPage || isExcluded) return
 
     logger.debug(`Running module: ${module.name}`)
 

--- a/src/modules/week-number/index.ts
+++ b/src/modules/week-number/index.ts
@@ -11,6 +11,7 @@ import { calcWeekNumber, parseDate } from '@modules/week-number/utils'
 const weekNumber: Module = {
   name: 'Week Number',
   pages: [pages.all],
+  excludePages: [pages.forum],
   run: () => {
     const elements = querySelectorAll('#mainBody .date', false)
 

--- a/src/modules/week-number/utils.ts
+++ b/src/modules/week-number/utils.ts
@@ -35,7 +35,8 @@ export const parseDate = (element: Element): Date | null => {
     return new Date(year, month - 1, day)
   }
 
-  logger.warn(`Unknown date format: ${value}`)
+  // On the series page, dates are replaced with the strings "Today" and "Yesterday", which don't need to be parsed
+  logger.debug(`Unknown date format: ${value}`)
 
   return null
 }


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the PR. -->

This PR disables the week-number module on the forum page; it's not useful there.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes in Firefox
- [x] I have tested my changes in Chromium-based browser
