### PR TITLE
Update week-number module to add dates when player tabs change on the player detail page

### DIFF
--- a/src/common/utils/dom.ts
+++ b/src/common/utils/dom.ts
@@ -117,3 +117,19 @@ export const querySelectorAllIn = <E extends Element = Element>(
 
   return elements
 }
+
+/**
+ * Observe an element for DOM changes and run a callback when mutations occur.
+ *
+ * @param element - The element to observe for changes
+ * @param callback - Function to execute when the element's children change
+ */
+export const observeElement = (element: Element, callback: () => void) => {
+  const observer = new MutationObserver(() => {
+    observer.disconnect()
+    callback()
+    observer.observe(element, { childList: true, subtree: true })
+  })
+
+  observer.observe(element, { childList: true, subtree: true })
+}


### PR DESCRIPTION
## Description

This PR fixes a bug where week numbers weren't added to tabs on the player detail page.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my changes in Firefox
- [x] I have tested my changes in Chromium-based browser
