### PR TITLE
Fix case-insensitive isPage check

### DIFF
--- a/src/entrypoints/content/common/utils/pages.test.ts
+++ b/src/entrypoints/content/common/utils/pages.test.ts
@@ -22,6 +22,12 @@ describe(isPage, () => {
         page: new Page('/Foo'),
         expected: true,
       },
+      {
+        desc: 'returns true when pathnames match case-insensitively',
+        currentPathname: '/foo',
+        page: new Page('/Foo'),
+        expected: true,
+      },
     ])('$desc', ({ currentPathname, page, expected }) => {
       vi.mocked(getCurrentPathname).mockReturnValue(currentPathname)
       vi.mocked(getCurrentSearchParams).mockReturnValue(new URLSearchParams())

--- a/src/entrypoints/content/common/utils/pages.ts
+++ b/src/entrypoints/content/common/utils/pages.ts
@@ -83,7 +83,7 @@ export const pages = {
  */
 export const isPage = (...pages: Page[]): boolean => {
   return pages.some((page) => {
-    if (page.pathname !== getCurrentPathname()) return false
+    if (page.pathname.toLowerCase() !== getCurrentPathname().toLowerCase()) return false
 
     const { options } = page
     if (!options) return true


### PR DESCRIPTION
Closes #34

## Description

The `isPage` check was doing a case-sensitive comparison of pathnames, causing it to fail on pages where the URL casing didn't exactly match the expected pattern. Fixed by lowercasing both sides of the pathname comparison.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (or tests already exist)
- [x] I have tested my changes in Firefox
- [x] I have tested my changes in a Chromium-based browser
- [ ] I have made corresponding changes to the documentation