### PR TITLE
Add skillshort denomination type

### DIFF
--- a/src/entrypoints/content/modules/denomination/constants.ts
+++ b/src/entrypoints/content/modules/denomination/constants.ts
@@ -11,6 +11,7 @@ export const DENOMINATION_TYPES = [
   'leadership',
   'morale',
   'skill',
+  'skillshort',
 ] as const
 
 export const PERSONALITY_TYPES = new Set<DenominationType>(['gentleness', 'honesty', 'aggressiveness'])
@@ -26,4 +27,5 @@ export const MAX_VALUES: Record<DenominationType, number> = {
   leadership: 7,
   morale: 10,
   skill: 20,
+  skillshort: 8,
 }


### PR DESCRIPTION
Closes #19

## Description

Adds `skillshort` as a supported denomination type with a max value of `8`.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (or tests already exist)
- [x] I have tested my changes in Firefox
- [ ] I have tested my changes in a Chromium-based browser
- [ ] I have made corresponding changes to the documentation