### PR TITLE
Add player card rates module

### DIFF
--- a/src/entrypoints/content/index.ts
+++ b/src/entrypoints/content/index.ts
@@ -13,11 +13,22 @@ import hatstats from '@/entrypoints/content/modules/hatstats'
 import hteVersion from '@/entrypoints/content/modules/hte-version'
 import htmsPoints from '@/entrypoints/content/modules/htms-points'
 import links from '@/entrypoints/content/modules/links'
+import playerCardRates from '@/entrypoints/content/modules/player-card-rates'
 import salary from '@/entrypoints/content/modules/salary'
 import skillBonus from '@/entrypoints/content/modules/skill-bonus'
 import weekNumber from '@/entrypoints/content/modules/week-number'
 
-const modules: Module[] = [links, skillBonus, htmsPoints, salary, hatstats, denomination, weekNumber, hteVersion]
+const modules: Module[] = [
+  links,
+  denomination,
+  weekNumber,
+  skillBonus,
+  htmsPoints,
+  salary,
+  hatstats,
+  playerCardRates,
+  hteVersion,
+]
 
 const getHandler = (module: Module): Handler | undefined => {
   if (module.pages instanceof Map) return module.pages.get(getCurrentPage())

--- a/src/entrypoints/content/modules/player-card-rates/constants.ts
+++ b/src/entrypoints/content/modules/player-card-rates/constants.ts
@@ -1,0 +1,37 @@
+/**
+ * Yellow card probability matrix based on a player's honesty and aggressiveness.
+ *
+ * Rows = aggressiveness, columns = honesty. Values are percentages.
+ *
+ * Both denominations are from 0 to 5 in Hattrick, but "saintly" honesty and "unstable" aggressiveness are excluded due
+ * to insufficient sample sizes.
+ *
+ * @see {@link https://stage.hattrick.org/Forum/Read.aspx?t=17665541&n=369&v=4}
+ */
+export const YELLOW_CARD_RATES: number[][] = [
+  // Infamous  Dishonest  Honest  Upright  Righteous
+  [2.7, 0.5, 0.6, 0.5, 0.5], // Tranquil
+  [7.9, 3.1, 1.7, 1.6, 1.7], // Calm
+  [10.6, 7.6, 4.9, 3.9, 3.7], // Balanced
+  [12.0, 10.7, 9.0, 7.6, 7.0], // Temperamental
+  [13.2, 12.7, 12.0, 11.4, 11.4], // Fiery
+]
+
+/**
+ * Red card probability matrix based on a player's honesty and aggressiveness.
+ *
+ * Rows = aggressiveness, columns = honesty. Values are percentages.
+ *
+ * Both denominations are from 0 to 5 in Hattrick, but "saintly" honesty and "unstable" aggressiveness are excluded due
+ * to insufficient sample sizes.
+ *
+ * @see {@link https://stage.hattrick.org/Forum/Read.aspx?t=17665541&n=369&v=4}
+ */
+export const RED_CARD_RATES: number[][] = [
+  // Infamous  Dishonest  Honest  Upright  Righteous
+  [0.08, 0.01, 0.02, 0.01, 0.01], // Tranquil
+  [0.36, 0.12, 0.08, 0.08, 0.08], // Calm
+  [0.66, 0.43, 0.27, 0.23, 0.23], // Balanced
+  [0.88, 0.78, 0.64, 0.55, 0.49], // Temperamental
+  [1.17, 1.12, 1.05, 0.99, 1.04], // Fiery
+]

--- a/src/entrypoints/content/modules/player-card-rates/index.css
+++ b/src/entrypoints/content/modules/player-card-rates/index.css
@@ -1,0 +1,32 @@
+.hte-card-icons {
+  float: right;
+  color: var(--hte-color-black);
+
+  .hte-card-icon {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    margin-left: 6px;
+    vertical-align: middle;
+    font-size: .9em;
+
+    &::before {
+      content: '';
+      display: inline-block;
+      width: 10px;
+      height: 14px;
+      border-radius: 2px;
+      flex-shrink: 0;
+    }
+  }
+
+  .hte-card-icon-yellow::before {
+    background-color: var(--hte-color-yellow-5);
+  }
+
+  .hte-card-icon-red::before {
+    background-color: var(--hte-color-red-8);
+  }
+}
+
+

--- a/src/entrypoints/content/modules/player-card-rates/index.ts
+++ b/src/entrypoints/content/modules/player-card-rates/index.ts
@@ -14,33 +14,27 @@ const makeCardIcon = (rate: number, type: 'yellow' | 'red'): HTMLSpanElement =>
     title: i18n.t(`player_card_rates_${type}_title`),
   })
 
-const run = (): void => {
-  const playerInfo = getElementById<HTMLDivElement>('ctl00_ctl00_CPContent_CPMain_pnlplayerInfo')
-  const byline = querySelector('#mainBody > .byline')
-  if (!playerInfo || !byline) return
-
-  const aggressiveness = getPersonalityLevel(playerInfo, 'aggressiveness')
-  const honesty = getPersonalityLevel(playerInfo, 'honesty')
-  if (honesty === null || aggressiveness === null) return
-
-  const rates = getCardRates(aggressiveness, honesty)
-  if (!rates) return
-
-  const { yellow, red } = rates
-
-  const wrapper = el('span', { className: 'hte-card-icons' })
-  wrapper.append(makeCardIcon(yellow, 'yellow'), makeCardIcon(red, 'red'))
-  byline.append(wrapper)
-}
-
 const playerCardRates: Module = {
   metadata,
-  pages: new Map([
-    [pages.playerDetail.senior.own, run],
-    [pages.playerDetail.senior.other, run],
-    [pages.playerDetail.youth.own, run],
-    [pages.playerDetail.youth.other, run],
-  ]),
+  pages: [pages.playerDetail.senior.own, pages.playerDetail.senior.other],
+  run: () => {
+    const playerInfo = getElementById<HTMLDivElement>('ctl00_ctl00_CPContent_CPMain_pnlplayerInfo')
+    const byline = querySelector('#mainBody > .byline')
+    if (!playerInfo || !byline) return
+
+    const aggressiveness = getPersonalityLevel(playerInfo, 'aggressiveness')
+    const honesty = getPersonalityLevel(playerInfo, 'honesty')
+    if (honesty === null || aggressiveness === null) return
+
+    const rates = getCardRates(aggressiveness, honesty)
+    if (!rates) return
+
+    const { yellow, red } = rates
+
+    const wrapper = el('span', { className: 'hte-card-icons' })
+    wrapper.append(makeCardIcon(yellow, 'yellow'), makeCardIcon(red, 'red'))
+    byline.append(wrapper)
+  },
 }
 
 export default playerCardRates

--- a/src/entrypoints/content/modules/player-card-rates/index.ts
+++ b/src/entrypoints/content/modules/player-card-rates/index.ts
@@ -1,0 +1,46 @@
+import '@/entrypoints/content/modules/player-card-rates/index.css'
+
+import { el } from '@/common/utils/dom'
+import type { Module } from '@/entrypoints/content/common/types/module'
+import { getElementById, querySelector } from '@/entrypoints/content/common/utils/dom'
+import { pages } from '@/entrypoints/content/common/utils/pages'
+import metadata from '@/entrypoints/content/modules/player-card-rates/metadata'
+import { formatRate, getCardRates, getPersonalityLevel } from '@/entrypoints/content/modules/player-card-rates/utils'
+
+const makeCardIcon = (rate: number, type: 'yellow' | 'red'): HTMLSpanElement =>
+  el('span', {
+    className: `hte-card-icon hte-card-icon-${type}`,
+    textContent: formatRate(rate),
+    title: i18n.t(`player_card_rates_${type}_title`),
+  })
+
+const run = (): void => {
+  const playerInfo = getElementById<HTMLDivElement>('ctl00_ctl00_CPContent_CPMain_pnlplayerInfo')
+  const byline = querySelector('#mainBody > .byline')
+  if (!playerInfo || !byline) return
+
+  const aggressiveness = getPersonalityLevel(playerInfo, 'aggressiveness')
+  const honesty = getPersonalityLevel(playerInfo, 'honesty')
+  if (honesty === null || aggressiveness === null) return
+
+  const rates = getCardRates(aggressiveness, honesty)
+  if (!rates) return
+
+  const { yellow, red } = rates
+
+  const wrapper = el('span', { className: 'hte-card-icons' })
+  wrapper.append(makeCardIcon(yellow, 'yellow'), makeCardIcon(red, 'red'))
+  byline.append(wrapper)
+}
+
+const playerCardRates: Module = {
+  metadata,
+  pages: new Map([
+    [pages.playerDetail.senior.own, run],
+    [pages.playerDetail.senior.other, run],
+    [pages.playerDetail.youth.own, run],
+    [pages.playerDetail.youth.other, run],
+  ]),
+}
+
+export default playerCardRates

--- a/src/entrypoints/content/modules/player-card-rates/metadata.ts
+++ b/src/entrypoints/content/modules/player-card-rates/metadata.ts
@@ -1,0 +1,9 @@
+import type { ModuleMetadata } from '@/entrypoints/content/common/types/module'
+
+const metadata = {
+  id: 'player-card-rates',
+  name: 'Player Card Rates',
+  description: 'Show the likelihood of a player receiving a yellow or red card based on their personality',
+} as const satisfies ModuleMetadata
+
+export default metadata

--- a/src/entrypoints/content/modules/player-card-rates/utils.test.ts
+++ b/src/entrypoints/content/modules/player-card-rates/utils.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { formatRate, getCardRates, getPersonalityLevel } from '@/entrypoints/content/modules/player-card-rates/utils'
+
+describe(getPersonalityLevel, () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <p>
+        <a class="skill" href="/Help/Rules/AppDenominations.aspx?lt=aggressiveness&ll=3#aggressiveness">balanced</a>
+        <a class="skill" href="/Help/Rules/AppDenominations.aspx?lt=honesty&ll=1#honesty">honest</a>
+      </p>`
+  })
+
+  it('parses aggressiveness level', () => {
+    expect(getPersonalityLevel(document.body, 'aggressiveness')).toBe(3)
+  })
+
+  it('parses honesty level', () => {
+    expect(getPersonalityLevel(document.body, 'honesty')).toBe(1)
+  })
+})
+
+describe(getCardRates, () => {
+  it('returns rates for a known combination', () => {
+    // Balanced (2) + Dishonest (1)
+    expect(getCardRates(2, 1)).toStrictEqual({ yellow: 7.6, red: 0.43 })
+  })
+
+  it('returns rates for minimum levels', () => {
+    // Infamous (0) + Tranquil (0)
+    expect(getCardRates(0, 0)).toStrictEqual({ yellow: 2.7, red: 0.08 })
+  })
+
+  it('returns rates for maximum levels', () => {
+    // Righteous (4) + Fiery (4)
+    expect(getCardRates(4, 4)).toStrictEqual({ yellow: 11.4, red: 1.04 })
+  })
+
+  it('returns null for unstable aggressiveness (level 5, no data)', () => {
+    expect(getCardRates(5, 2)).toBeNull()
+  })
+
+  it('returns null for saint-like honesty (level 5, no data)', () => {
+    expect(getCardRates(2, 5)).toBeNull()
+  })
+})
+
+describe(formatRate, () => {
+  it('formats two decimal places', () => {
+    expect(formatRate(0.43)).toBe('0,43%')
+  })
+
+  it('strips trailing zeros', () => {
+    expect(formatRate(3.0)).toBe('3%')
+  })
+})

--- a/src/entrypoints/content/modules/player-card-rates/utils.ts
+++ b/src/entrypoints/content/modules/player-card-rates/utils.ts
@@ -1,0 +1,22 @@
+import { querySelectorIn } from '@/entrypoints/content/common/utils/dom'
+import { RED_CARD_RATES, YELLOW_CARD_RATES } from '@/entrypoints/content/modules/player-card-rates/constants'
+
+export const getPersonalityLevel = (playerInfo: Element, lt: 'aggressiveness' | 'honesty'): number | null => {
+  const link = querySelectorIn<HTMLAnchorElement>(playerInfo, `a.skill[href*="lt=${lt}"]`, false)
+  if (!link) return null
+
+  const ll = new URL(link.href).searchParams.get('ll')
+  if (!ll) return null
+
+  return parseInt(ll, 10)
+}
+
+export const getCardRates = (aggressiveness: number, honesty: number): { yellow: number; red: number } | null => {
+  if (aggressiveness >= YELLOW_CARD_RATES.length || honesty >= YELLOW_CARD_RATES[0].length) return null
+  return { yellow: YELLOW_CARD_RATES[aggressiveness][honesty], red: RED_CARD_RATES[aggressiveness][honesty] }
+}
+
+export const formatRate = (value: number): string => {
+  const fixed = value.toFixed(2)
+  return `${parseFloat(fixed)}%`.replace('.', ',')
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,5 +37,11 @@
   },
   "hatstats_away": {
     "message": "Away"
+  },
+  "player_card_rates_yellow_title": {
+    "message": "Probability of a player receiving a yellow card, based on aggressiveness and honesty."
+  },
+  "player_card_rates_red_title": {
+    "message": "Probability of a player receiving a red card, based on aggressiveness and honesty."
   }
 }


### PR DESCRIPTION
Closes #10

## Description

Adds a new `player-card-rates` module that displays expected yellow and red card probabilities on player detail pages.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works (or tests already exist)
- [x] I have tested my changes in Firefox
- [ ] I have tested my changes in a Chromium-based browser
- [ ] I have made corresponding changes to the documentation