### PR TITLE
Add player TS drop rates module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,8 +115,7 @@ All pnpm scripts are located in [package.json](https://github.com/session567/hte
 
 2. Create `index.ts` in the same directory.
 
-   This is the main module file. It defines which pages the module runs on. All modules run concurrently, so `run()`
-   and handlers must not depend on another module having already finished.
+   This is the main module file. It defines which pages the module runs on.
 
    There are two module shapes:
 
@@ -172,6 +171,20 @@ All pnpm scripts are located in [package.json](https://github.com/session567/hte
 
    For a dispatched module example, see
    [src/entrypoints/content/modules/hatstats/index.ts](https://github.com/session567/hte/blob/main/src/entrypoints/content/modules/hatstats/index.ts).
+
+   All modules run concurrently by default. If your module must run after another (e.g. because both append to the same
+   DOM element and the order matters), use `runAfter`:
+
+    ```typescript
+    import otherModule from '@/entrypoints/content/modules/other-module'
+
+    const exampleModule: Module = {
+      metadata,
+      runAfter: [otherModule],
+      pages: [...],
+      run: () => { ... },
+    }
+    ```
 
 3. Register your module in `src/entrypoints/content/index.ts`:
 

--- a/src/entrypoints/content/common/types/module.ts
+++ b/src/entrypoints/content/common/types/module.ts
@@ -29,7 +29,10 @@ export type ModuleMetadata = {
   settings?: Record<string, ModuleSetting>
 }
 
-type BaseModule = { metadata: ModuleMetadata }
+type BaseModule = {
+  metadata: ModuleMetadata
+  runAfter?: Module[]
+}
 
 export type Handler = () => void | Promise<void>
 

--- a/src/entrypoints/content/common/utils/format.test.ts
+++ b/src/entrypoints/content/common/utils/format.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatPercentage } from '@/entrypoints/content/common/utils/format'
+
+describe(formatPercentage, () => {
+  it.each([
+    { value: 0.43, expected: '0,43%' },
+    { value: 3.0, expected: '3%' },
+    { value: 69, expected: '69%' },
+    { value: 0, expected: '0%' },
+  ])('formats $value as $expected', ({ value, expected }) => {
+    expect(formatPercentage(value)).toBe(expected)
+  })
+})

--- a/src/entrypoints/content/common/utils/format.ts
+++ b/src/entrypoints/content/common/utils/format.ts
@@ -1,0 +1,10 @@
+/**
+ * Format a number as a percentage string.
+ *
+ * @example formatPercentage(0.43) // "0,43%"
+ * @example formatPercentage(69) // "69%"
+ */
+export const formatPercentage = (value: number): string => {
+  const fixed = value.toFixed(2)
+  return `${parseFloat(fixed)}%`.replace('.', ',')
+}

--- a/src/entrypoints/content/common/utils/player/utils.test.ts
+++ b/src/entrypoints/content/common/utils/player/utils.test.ts
@@ -3,7 +3,27 @@ import { describe, expect, it } from 'vitest'
 import { createElement } from '@/entrypoints/content/common/test/utils'
 import { logger } from '@/entrypoints/content/common/utils/logger'
 import { PlayerSkills } from '@/entrypoints/content/common/utils/player/constants'
-import { parsePlayerAge, parsePlayerSkills } from '@/entrypoints/content/common/utils/player/utils'
+import { getPersonalityLevel, parsePlayerAge, parsePlayerSkills } from '@/entrypoints/content/common/utils/player/utils'
+
+describe(getPersonalityLevel, () => {
+  it('parses personality levels', () => {
+    document.body.innerHTML = `
+      <div id="ctl00_ctl00_CPContent_CPMain_pnlplayerInfo">
+        <a class="skill" href="/Help/Rules/AppDenominations.aspx?lt=gentleness&ll=2"></a>
+        <a class="skill" href="/Help/Rules/AppDenominations.aspx?lt=aggressiveness&ll=3"></a>
+        <a class="skill" href="/Help/Rules/AppDenominations.aspx?lt=honesty&ll=1"></a>
+      </div>
+    `
+
+    expect(getPersonalityLevel('aggressiveness')).toBe(3)
+    expect(getPersonalityLevel('honesty')).toBe(1)
+    expect(getPersonalityLevel('gentleness')).toBe(2)
+  })
+
+  it('returns null when player info element is absent', () => {
+    expect(getPersonalityLevel('aggressiveness')).toBeNull()
+  })
+})
 
 describe(parsePlayerAge, () => {
   it.each([

--- a/src/entrypoints/content/common/utils/player/utils.ts
+++ b/src/entrypoints/content/common/utils/player/utils.ts
@@ -1,4 +1,4 @@
-import { querySelectorAllIn, querySelectorIn } from '@/entrypoints/content/common/utils/dom'
+import { getElementById, querySelectorAllIn, querySelectorIn } from '@/entrypoints/content/common/utils/dom'
 import { logger } from '@/entrypoints/content/common/utils/logger'
 import { NUM_OF_SKILLS, PlayerAge, PlayerSkills, Skill } from '@/entrypoints/content/common/utils/player/constants'
 
@@ -64,4 +64,20 @@ export const parsePlayerSkills = (element: Element): PlayerSkills | null => {
   }
 
   return skills as PlayerSkills
+}
+
+/**
+ * Get a player's personality level by querying the denomination link for the given trait.
+ */
+export const getPersonalityLevel = (lt: 'gentleness' | 'aggressiveness' | 'honesty'): number | null => {
+  const playerInfo = getElementById<HTMLDivElement>('ctl00_ctl00_CPContent_CPMain_pnlplayerInfo')
+  if (!playerInfo) return null
+
+  const link = querySelectorIn<HTMLAnchorElement>(playerInfo, `a.skill[href*="lt=${lt}"]`, false)
+  if (!link) return null
+
+  const ll = new URLSearchParams(link.search).get('ll')
+  if (!ll) return null
+
+  return parseInt(ll, 10)
 }

--- a/src/entrypoints/content/index.ts
+++ b/src/entrypoints/content/index.ts
@@ -14,20 +14,22 @@ import hteVersion from '@/entrypoints/content/modules/hte-version'
 import htmsPoints from '@/entrypoints/content/modules/htms-points'
 import links from '@/entrypoints/content/modules/links'
 import playerCardRates from '@/entrypoints/content/modules/player-card-rates'
+import playerTsDropRates from '@/entrypoints/content/modules/player-ts-drop-rates'
 import salary from '@/entrypoints/content/modules/salary'
 import skillBonus from '@/entrypoints/content/modules/skill-bonus'
 import weekNumber from '@/entrypoints/content/modules/week-number'
 
 const modules: Module[] = [
   links,
-  denomination,
   weekNumber,
+  denomination,
   skillBonus,
   htmsPoints,
   salary,
-  hatstats,
   playerCardRates,
+  playerTsDropRates,
   hteVersion,
+  hatstats,
 ]
 
 const getHandler = (module: Module): Handler | undefined => {
@@ -54,6 +56,22 @@ const runModule = async (module: Module): Promise<void> => {
   }
 }
 
+const runModules = async (modules: Module[]): Promise<void> => {
+  const promises = new Map<string, Promise<void>>()
+
+  const getPromise = (module: Module): Promise<void> => {
+    const cached = promises.get(module.metadata.id)
+    if (cached) return cached
+
+    const deps = (module.runAfter ?? []).map(getPromise)
+    const promise = Promise.all(deps).then(() => runModule(module))
+    promises.set(module.metadata.id, promise)
+    return promise
+  }
+
+  await Promise.all(modules.map(getPromise))
+}
+
 export default defineContentScript({
   matches: ['https://*.hattrick.org/*'],
   async main() {
@@ -65,6 +83,6 @@ export default defineContentScript({
     logger.debug('Running HTE')
     logger.debug(`Current pathname: ${getCurrentPathname()}`)
 
-    await Promise.all(modules.map(runModule))
+    await runModules(modules)
   },
 })

--- a/src/entrypoints/content/modules/player-card-rates/index.ts
+++ b/src/entrypoints/content/modules/player-card-rates/index.ts
@@ -2,15 +2,17 @@ import '@/entrypoints/content/modules/player-card-rates/index.css'
 
 import { el } from '@/common/utils/dom'
 import type { Module } from '@/entrypoints/content/common/types/module'
-import { getElementById, querySelector } from '@/entrypoints/content/common/utils/dom'
+import { querySelector } from '@/entrypoints/content/common/utils/dom'
+import { formatPercentage } from '@/entrypoints/content/common/utils/format'
 import { pages } from '@/entrypoints/content/common/utils/pages'
+import { getPersonalityLevel } from '@/entrypoints/content/common/utils/player/utils'
 import metadata from '@/entrypoints/content/modules/player-card-rates/metadata'
-import { formatRate, getCardRates, getPersonalityLevel } from '@/entrypoints/content/modules/player-card-rates/utils'
+import { getCardRates } from '@/entrypoints/content/modules/player-card-rates/utils'
 
 const makeCardIcon = (rate: number, type: 'yellow' | 'red'): HTMLSpanElement =>
   el('span', {
     className: `hte-card-icon hte-card-icon-${type}`,
-    textContent: formatRate(rate),
+    textContent: formatPercentage(rate),
     title: i18n.t(`player_card_rates_${type}_title`),
   })
 
@@ -18,12 +20,11 @@ const playerCardRates: Module = {
   metadata,
   pages: [pages.playerDetail.senior.own, pages.playerDetail.senior.other],
   run: () => {
-    const playerInfo = getElementById<HTMLDivElement>('ctl00_ctl00_CPContent_CPMain_pnlplayerInfo')
     const byline = querySelector('#mainBody > .byline')
-    if (!playerInfo || !byline) return
+    if (!byline) return
 
-    const aggressiveness = getPersonalityLevel(playerInfo, 'aggressiveness')
-    const honesty = getPersonalityLevel(playerInfo, 'honesty')
+    const aggressiveness = getPersonalityLevel('aggressiveness')
+    const honesty = getPersonalityLevel('honesty')
     if (honesty === null || aggressiveness === null) return
 
     const rates = getCardRates(aggressiveness, honesty)

--- a/src/entrypoints/content/modules/player-card-rates/utils.test.ts
+++ b/src/entrypoints/content/modules/player-card-rates/utils.test.ts
@@ -1,39 +1,14 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-import { formatRate, getCardRates, getPersonalityLevel } from '@/entrypoints/content/modules/player-card-rates/utils'
-
-describe(getPersonalityLevel, () => {
-  beforeEach(() => {
-    document.body.innerHTML = `
-      <p>
-        <a class="skill" href="/Help/Rules/AppDenominations.aspx?lt=aggressiveness&ll=3#aggressiveness">balanced</a>
-        <a class="skill" href="/Help/Rules/AppDenominations.aspx?lt=honesty&ll=1#honesty">honest</a>
-      </p>`
-  })
-
-  it('parses aggressiveness level', () => {
-    expect(getPersonalityLevel(document.body, 'aggressiveness')).toBe(3)
-  })
-
-  it('parses honesty level', () => {
-    expect(getPersonalityLevel(document.body, 'honesty')).toBe(1)
-  })
-})
+import { getCardRates } from '@/entrypoints/content/modules/player-card-rates/utils'
 
 describe(getCardRates, () => {
-  it('returns rates for a known combination', () => {
-    // Balanced (2) + Dishonest (1)
-    expect(getCardRates(2, 1)).toStrictEqual({ yellow: 7.6, red: 0.43 })
-  })
-
-  it('returns rates for minimum levels', () => {
-    // Infamous (0) + Tranquil (0)
-    expect(getCardRates(0, 0)).toStrictEqual({ yellow: 2.7, red: 0.08 })
-  })
-
-  it('returns rates for maximum levels', () => {
-    // Righteous (4) + Fiery (4)
-    expect(getCardRates(4, 4)).toStrictEqual({ yellow: 11.4, red: 1.04 })
+  it.each([
+    { desc: 'Infamous + Tranquil', aggressiveness: 0, honesty: 0, expected: { yellow: 2.7, red: 0.08 } },
+    { desc: 'Balanced + Dishonest', aggressiveness: 2, honesty: 1, expected: { yellow: 7.6, red: 0.43 } },
+    { desc: 'Righteous + Fiery', aggressiveness: 4, honesty: 4, expected: { yellow: 11.4, red: 1.04 } },
+  ])('returns rates for $desc', ({ aggressiveness, honesty, expected }) => {
+    expect(getCardRates(aggressiveness, honesty)).toStrictEqual(expected)
   })
 
   it('returns null for unstable aggressiveness (level 5, no data)', () => {
@@ -42,15 +17,5 @@ describe(getCardRates, () => {
 
   it('returns null for saint-like honesty (level 5, no data)', () => {
     expect(getCardRates(2, 5)).toBeNull()
-  })
-})
-
-describe(formatRate, () => {
-  it('formats two decimal places', () => {
-    expect(formatRate(0.43)).toBe('0,43%')
-  })
-
-  it('strips trailing zeros', () => {
-    expect(formatRate(3.0)).toBe('3%')
   })
 })

--- a/src/entrypoints/content/modules/player-card-rates/utils.ts
+++ b/src/entrypoints/content/modules/player-card-rates/utils.ts
@@ -1,22 +1,6 @@
-import { querySelectorIn } from '@/entrypoints/content/common/utils/dom'
 import { RED_CARD_RATES, YELLOW_CARD_RATES } from '@/entrypoints/content/modules/player-card-rates/constants'
-
-export const getPersonalityLevel = (playerInfo: Element, lt: 'aggressiveness' | 'honesty'): number | null => {
-  const link = querySelectorIn<HTMLAnchorElement>(playerInfo, `a.skill[href*="lt=${lt}"]`, false)
-  if (!link) return null
-
-  const ll = new URL(link.href).searchParams.get('ll')
-  if (!ll) return null
-
-  return parseInt(ll, 10)
-}
 
 export const getCardRates = (aggressiveness: number, honesty: number): { yellow: number; red: number } | null => {
   if (aggressiveness >= YELLOW_CARD_RATES.length || honesty >= YELLOW_CARD_RATES[0].length) return null
   return { yellow: YELLOW_CARD_RATES[aggressiveness][honesty], red: RED_CARD_RATES[aggressiveness][honesty] }
-}
-
-export const formatRate = (value: number): string => {
-  const fixed = value.toFixed(2)
-  return `${parseFloat(fixed)}%`.replace('.', ',')
 }

--- a/src/entrypoints/content/modules/player-ts-drop-rates/constants.ts
+++ b/src/entrypoints/content/modules/player-ts-drop-rates/constants.ts
@@ -1,0 +1,9 @@
+/**
+ * The changes for team spirit to drop when buying/selling a player, based on their gentleness level.
+ *
+ * Indexed by gentleness level: 0=Nasty, 1=Controversial, 2=Pleasant, 3=Sympathetic, 4=Popular
+ *
+ * @See {@link https://stage.hattrick.org/Forum/Read.aspx?t=17665541&n=44&v=4&mr=0}
+ */
+export const BUY_TS_DROP_RATES = [69, 47, 30, 0, 0]
+export const SELL_TS_DROP_RATES = [0, 0, 12, 22, 27]

--- a/src/entrypoints/content/modules/player-ts-drop-rates/index.css
+++ b/src/entrypoints/content/modules/player-ts-drop-rates/index.css
@@ -1,0 +1,30 @@
+.hte-ts-drop-icons {
+  float: right;
+  color: var(--hte-color-black);
+
+  .hte-ts-drop-icon {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    margin-left: 6px;
+    vertical-align: middle;
+    font-size: .9em;
+
+    &::before {
+      content: '';
+      display: inline-block;
+      width: 14px;
+      height: 14px;
+      flex-shrink: 0;
+      background-color: currentcolor;
+    }
+  }
+
+  .hte-ts-drop-icon-buy::before {
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m10 17 5-5-5-5'/><path d='M15 12H3'/><path d='M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4'/></svg>") no-repeat center / contain;
+  }
+
+  .hte-ts-drop-icon-sell::before {
+    mask: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m16 17 5-5-5-5'/><path d='M21 12H9'/><path d='M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4'/></svg>") no-repeat center / contain;
+  }
+}

--- a/src/entrypoints/content/modules/player-ts-drop-rates/index.ts
+++ b/src/entrypoints/content/modules/player-ts-drop-rates/index.ts
@@ -1,0 +1,42 @@
+import '@/entrypoints/content/modules/player-ts-drop-rates/index.css'
+
+import { el } from '@/common/utils/dom'
+import type { Module } from '@/entrypoints/content/common/types/module'
+import { querySelector } from '@/entrypoints/content/common/utils/dom'
+import { formatPercentage } from '@/entrypoints/content/common/utils/format'
+import { pages } from '@/entrypoints/content/common/utils/pages'
+import { getPersonalityLevel } from '@/entrypoints/content/common/utils/player/utils'
+import playerCardRates from '@/entrypoints/content/modules/player-card-rates'
+import metadata from '@/entrypoints/content/modules/player-ts-drop-rates/metadata'
+import { getTsDropRates } from '@/entrypoints/content/modules/player-ts-drop-rates/utils'
+
+const makeTsIcon = (rate: number, type: 'buy' | 'sell'): HTMLSpanElement =>
+  el('span', {
+    className: `hte-ts-drop-icon hte-ts-drop-icon-${type}`,
+    textContent: formatPercentage(rate),
+    title: i18n.t(`player_ts_drop_rates_${type}_title`),
+  })
+
+const playerTsDropRates: Module = {
+  metadata,
+  runAfter: [playerCardRates],
+  pages: [pages.playerDetail.senior.own, pages.playerDetail.senior.other],
+  run: () => {
+    const byline = querySelector('#mainBody > .byline')
+    if (!byline) return
+
+    const gentleness = getPersonalityLevel('gentleness')
+    if (gentleness === null) return
+
+    const rates = getTsDropRates(gentleness)
+    if (!rates) return
+
+    const { buy, sell } = rates
+
+    const wrapper = el('span', { className: 'hte-ts-drop-icons' })
+    wrapper.append(makeTsIcon(buy, 'buy'), makeTsIcon(sell, 'sell'))
+    byline.append(wrapper)
+  },
+}
+
+export default playerTsDropRates

--- a/src/entrypoints/content/modules/player-ts-drop-rates/metadata.ts
+++ b/src/entrypoints/content/modules/player-ts-drop-rates/metadata.ts
@@ -1,0 +1,9 @@
+import type { ModuleMetadata } from '@/entrypoints/content/common/types/module'
+
+const metadata = {
+  id: 'player-ts-drop-rates',
+  name: 'Player Team Spirit Drop',
+  description: 'Show the likelihood of a team spirit drop when buying or selling a player based on their personality',
+} as const satisfies ModuleMetadata
+
+export default metadata

--- a/src/entrypoints/content/modules/player-ts-drop-rates/utils.test.ts
+++ b/src/entrypoints/content/modules/player-ts-drop-rates/utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { getTsDropRates } from '@/entrypoints/content/modules/player-ts-drop-rates/utils'
+
+describe(getTsDropRates, () => {
+  it.each([
+    { level: 0, name: 'Nasty', expected: { buy: 69, sell: 0 } },
+    { level: 1, name: 'Controversial', expected: { buy: 47, sell: 0 } },
+    { level: 2, name: 'Pleasant', expected: { buy: 30, sell: 12 } },
+    { level: 3, name: 'Sympathetic', expected: { buy: 0, sell: 22 } },
+    { level: 4, name: 'Popular', expected: { buy: 0, sell: 27 } },
+  ])('returns rates for $name ($level)', ({ level, expected }) => {
+    expect(getTsDropRates(level)).toStrictEqual(expected)
+  })
+
+  it.each([-1, 5])('returns null for out-of-range level %i', (level) => {
+    expect(getTsDropRates(level)).toBeNull()
+  })
+})

--- a/src/entrypoints/content/modules/player-ts-drop-rates/utils.ts
+++ b/src/entrypoints/content/modules/player-ts-drop-rates/utils.ts
@@ -1,0 +1,6 @@
+import { BUY_TS_DROP_RATES, SELL_TS_DROP_RATES } from '@/entrypoints/content/modules/player-ts-drop-rates/constants'
+
+export const getTsDropRates = (gentleness: number): { buy: number; sell: number } | null => {
+  if (gentleness < 0 || gentleness >= BUY_TS_DROP_RATES.length) return null
+  return { buy: BUY_TS_DROP_RATES[gentleness], sell: SELL_TS_DROP_RATES[gentleness] }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -43,5 +43,11 @@
   },
   "player_card_rates_red_title": {
     "message": "Probability of a player receiving a red card, based on aggressiveness and honesty."
+  },
+  "player_ts_drop_rates_buy_title": {
+    "message": "Probability of a team spirit drop when buying this player, based on their personality."
+  },
+  "player_ts_drop_rates_sell_title": {
+    "message": "Probability of a team spirit drop when selling this player, based on their personality."
   }
 }


### PR DESCRIPTION
Closes #22

## Description

Adds a new `player-ts-drop-rates` module that displays the probability of a team spirit drop when buying or selling a player, based on their gentleness personality trait.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works (or tests already exist)
- [x] I have tested my changes in Firefox
- [ ] I have tested my changes in a Chromium-based browser
- [ ] I have made corresponding changes to the documentation