### PR TITLE
Highlight players close to aging up

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Features:
 - Display numeric values next to all team and player abilities
 - Display week numbers next to dates throughout Hattrick
 - Display HatStats ratings on match detail and match order pages
+- Show the likelihood of a player receiving a yellow or red card based on their personality
+- Show the likelihood of a team spirit drop when buying or selling a player based on their personality
+- Highlight players in transfer search results that are close to aging up
 
 ## Installation
 

--- a/src/entrypoints/content/common/types/module.ts
+++ b/src/entrypoints/content/common/types/module.ts
@@ -11,7 +11,7 @@ export type ModuleSetting = {
   default: boolean
 }
 
-export type ModuleGroup = 'general' | 'match' | 'player'
+export type ModuleGroup = 'general' | 'match' | 'player' | 'transfer'
 
 /**
  * Metadata for a module.

--- a/src/entrypoints/content/index.ts
+++ b/src/entrypoints/content/index.ts
@@ -17,6 +17,7 @@ import playerHtmsPoints from '@/entrypoints/content/modules/player-htms-points'
 import playerSalary from '@/entrypoints/content/modules/player-salary'
 import playerSkillBonus from '@/entrypoints/content/modules/player-skill-bonus'
 import playerTsDropRates from '@/entrypoints/content/modules/player-ts-drop-rates'
+import transferAge from '@/entrypoints/content/modules/transfer-age'
 import weekNumber from '@/entrypoints/content/modules/week-number'
 
 const modules: Module[] = [
@@ -28,6 +29,7 @@ const modules: Module[] = [
   playerSalary,
   playerCardRates,
   playerTsDropRates,
+  transferAge,
   hteVersion,
   matchHatstats,
 ]

--- a/src/entrypoints/content/modules/transfer-age/index.css
+++ b/src/entrypoints/content/modules/transfer-age/index.css
@@ -1,0 +1,52 @@
+#hte-transfer-age-settings {
+  display: flex;
+  gap: 12px;
+  float: right;
+  margin-top: -2px;
+
+  .hte-transfer-age-label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .hte-transfer-age-swatch {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    flex-shrink: 0;
+
+    &.hte-transfer-age-swatch-orange {
+      background-color: var(--hte-color-orange-4);
+    }
+
+    &.hte-transfer-age-swatch-red {
+      background-color: var(--hte-color-red-6);
+    }
+  }
+
+  .hte-transfer-age-input {
+    width: 44px;
+    text-align: center;
+  }
+}
+
+.hte-transfer-age {
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+
+  &.hte-transfer-age-green {
+    text-decoration-color: var(--hte-hattrick-light-green);
+  }
+
+  &.hte-transfer-age-orange {
+    text-decoration-color: var(--hte-color-orange-4);
+  }
+
+  &.hte-transfer-age-red {
+    text-decoration-color: var(--hte-color-red-6);
+  }
+}
+
+

--- a/src/entrypoints/content/modules/transfer-age/index.ts
+++ b/src/entrypoints/content/modules/transfer-age/index.ts
@@ -1,0 +1,84 @@
+import '@/entrypoints/content/modules/transfer-age/index.css'
+
+import { el } from '@/common/utils/dom'
+import type { Module } from '@/entrypoints/content/common/types/module'
+import { DAYS_PER_SEASON } from '@/entrypoints/content/common/utils/constants'
+import { querySelector, querySelectorAll, querySelectorIn } from '@/entrypoints/content/common/utils/dom'
+import { pages } from '@/entrypoints/content/common/utils/pages'
+import { parsePlayerAge } from '@/entrypoints/content/common/utils/player/utils'
+import metadata from '@/entrypoints/content/modules/transfer-age/metadata'
+import { thresholdsStorage } from '@/entrypoints/content/modules/transfer-age/utils'
+
+const createThresholdControl = (
+  color: 'orange' | 'red',
+  value: number,
+): { label: HTMLLabelElement; input: HTMLInputElement } => {
+  const label = el('label', { className: 'hte-transfer-age-label' })
+  const swatch = el('span', { className: `hte-transfer-age-swatch hte-transfer-age-swatch-${color}` })
+  const input = el('input', {
+    type: 'number',
+    className: 'hte-transfer-age-input',
+    min: '0',
+    max: String(DAYS_PER_SEASON - 1),
+    value: String(value),
+  })
+  label.append(swatch, ` ${i18n.t('transfer_age_older_than')} `, input, ` ${i18n.t('transfer_age_days')}`)
+
+  return { label, input }
+}
+
+const injectSettingsPanel = (red: number, orange: number): void => {
+  querySelector('#hte-transfer-age-settings', false)?.remove()
+
+  const { label: orangeLabel, input: orangeInput } = createThresholdControl('orange', orange)
+  const { label: redLabel, input: redInput } = createThresholdControl('red', red)
+
+  const panel = el('div', { id: 'hte-transfer-age-settings' })
+  panel.append(orangeLabel, redLabel)
+
+  const onThresholdChange = () => {
+    const newOrange = parseInt(orangeInput.value, 10)
+    const newRed = parseInt(redInput.value, 10)
+    if (isNaN(newOrange) || isNaN(newRed)) return
+
+    void thresholdsStorage.setValue({ red: newRed, orange: newOrange }).then(() => {
+      applyHighlights(newRed, newOrange)
+    })
+  }
+
+  orangeInput.addEventListener('change', onThresholdChange)
+  redInput.addEventListener('change', onThresholdChange)
+
+  querySelector('#ctl00_ctl00_CPContent_CPMain_ucPager_divWrapper .PagerRight_Default')?.prepend(panel)
+}
+
+const applyHighlights = (red: number, orange: number): void => {
+  const players = querySelectorAll<HTMLElement>('.transferPlayerInformation', false)
+
+  players.forEach((player) => {
+    const ageCell = querySelectorIn<HTMLTableCellElement>(player, 'table tr:nth-child(2) td:nth-child(2)', false)
+    if (!ageCell) return
+
+    const age = parsePlayerAge(ageCell)
+    if (!age) return
+
+    const { days } = age
+    const className =
+      days >= red ? 'hte-transfer-age-red' : days >= orange ? 'hte-transfer-age-orange' : 'hte-transfer-age-green'
+
+    ageCell.classList.remove('hte-transfer-age-red', 'hte-transfer-age-orange', 'hte-transfer-age-green')
+    ageCell.classList.add('hte-transfer-age', className)
+  })
+}
+
+const transferAge: Module = {
+  metadata,
+  pages: [pages.transferSearchResults],
+  run: async () => {
+    const { red, orange } = await thresholdsStorage.getValue()
+    injectSettingsPanel(red, orange)
+    applyHighlights(red, orange)
+  },
+}
+
+export default transferAge

--- a/src/entrypoints/content/modules/transfer-age/metadata.ts
+++ b/src/entrypoints/content/modules/transfer-age/metadata.ts
@@ -1,0 +1,10 @@
+import type { ModuleMetadata } from '@/entrypoints/content/common/types/module'
+
+const metadata = {
+  id: 'transfer-age',
+  group: 'transfer',
+  name: 'Transfer Age',
+  description: 'Color player ages on transfer search results to highlight players that are close to aging up.',
+} as const satisfies ModuleMetadata
+
+export default metadata

--- a/src/entrypoints/content/modules/transfer-age/utils.ts
+++ b/src/entrypoints/content/modules/transfer-age/utils.ts
@@ -1,0 +1,6 @@
+export const DEFAULTS = { orange: 80, red: 90 } as const
+
+export const thresholdsStorage = storage.defineItem<{ red: number; orange: number }>('local:transfer-age-thresholds', {
+  fallback: DEFAULTS,
+  version: 1,
+})

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -38,6 +38,12 @@
   "hatstats_away": {
     "message": "Away"
   },
+  "transfer_age_older_than": {
+    "message": "Older than"
+  },
+  "transfer_age_days": {
+    "message": "days"
+  },
   "player_card_rates_yellow_title": {
     "message": "Probability of a player receiving a yellow card, based on aggressiveness and honesty."
   },


### PR DESCRIPTION
Closes #17

## Description

Adds a new `transfer-age` module that highlights player ages on transfer search results based on configurable day thresholds. Players close to aging up are underlined in orange or red; players with plenty of time remaining are underlined in green.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (or tests already exist)
- [x] I have tested my changes in Firefox
- [ ] I have tested my changes in a Chromium-based browser
- [ ] I have made corresponding changes to the documentation