### PR TITLE
Fix denomination and week number on pre-match and office pages

### DIFF
--- a/src/entrypoints/content/common/utils/pages/pages.ts
+++ b/src/entrypoints/content/common/utils/pages/pages.ts
@@ -29,6 +29,7 @@ export const pages = {
     youth: teamPages('/Club/Matches/', { queryParams: [{ name: 'YouthTeamId' }] }),
   },
   matchOrder: new Page('/Club/Matches/MatchOrder/MatchOrder.aspx'),
+  office: new Page('/MyHattrick/Office/'),
   playerDetail: {
     senior: teamPages('/Club/Players/Player.aspx'),
     youth: teamPages('/Club/Players/YouthPlayer.aspx'),

--- a/src/entrypoints/content/modules/denomination/index.ts
+++ b/src/entrypoints/content/modules/denomination/index.ts
@@ -2,9 +2,10 @@ import '@/entrypoints/content/modules/denomination/index.css'
 
 import { el } from '@/common/utils/dom'
 import type { Module } from '@/entrypoints/content/common/types/module'
-import { querySelectorAll } from '@/entrypoints/content/common/utils/dom'
+import { querySelectorAll, waitForElement } from '@/entrypoints/content/common/utils/dom'
 import { logger } from '@/entrypoints/content/common/utils/logger'
-import { pages } from '@/entrypoints/content/common/utils/pages'
+import { getHtMatch } from '@/entrypoints/content/common/utils/match/utils'
+import { isCurrentPage, pages } from '@/entrypoints/content/common/utils/pages'
 import { MAX_VALUES, PERSONALITY_TYPES } from '@/entrypoints/content/modules/denomination/constants'
 import metadata from '@/entrypoints/content/modules/denomination/metadata'
 import { adjustDenominationValue, isDenominationType } from '@/entrypoints/content/modules/denomination/utils'
@@ -16,8 +17,10 @@ const denomination: Module = {
   metadata,
   pages: [pages.all],
   run: async () => {
-    const links = querySelectorAll<HTMLAnchorElement>(`a.skill[href*="${pages.appDenominations.pathname}"]`, false)
+    if (isCurrentPage(pages.matchDetail.senior)) await getHtMatch()
+    if (isCurrentPage(pages.office)) await waitForElement('ht-office ht-widget-team-summary')
 
+    const links = querySelectorAll<HTMLAnchorElement>(`a[href*="${pages.appDenominations.pathname}"]`, false)
     for (const link of links) {
       const url = new URL(link.href)
       const lt = url.searchParams.get('lt')

--- a/src/entrypoints/content/modules/denomination/index.ts
+++ b/src/entrypoints/content/modules/denomination/index.ts
@@ -18,7 +18,7 @@ const denomination: Module = {
   pages: [pages.all],
   run: async () => {
     if (isCurrentPage(pages.matchDetail.senior)) await getHtMatch()
-    if (isCurrentPage(pages.office)) await waitForElement('ht-office ht-widget-team-summary')
+    else if (isCurrentPage(pages.office)) await waitForElement('ht-office ht-widget-team-summary')
 
     const links = querySelectorAll<HTMLAnchorElement>(`a[href*="${pages.appDenominations.pathname}"]`, false)
     for (const link of links) {

--- a/src/entrypoints/content/modules/week-number/handlers/office.ts
+++ b/src/entrypoints/content/modules/week-number/handlers/office.ts
@@ -1,0 +1,10 @@
+import { waitForElement } from '@/entrypoints/content/common/utils/dom'
+import { addWeekNumbers } from '@/entrypoints/content/modules/week-number/utils'
+
+const runOffice = async () => {
+  const htMatchList = await waitForElement('ht-office ht-match-list')
+  if (!htMatchList) return
+  addWeekNumbers(htMatchList, '.match-date span')
+}
+
+export default runOffice

--- a/src/entrypoints/content/modules/week-number/index.ts
+++ b/src/entrypoints/content/modules/week-number/index.ts
@@ -3,6 +3,7 @@ import '@/entrypoints/content/modules/week-number/index.css'
 import type { Module } from '@/entrypoints/content/common/types/module'
 import { pages } from '@/entrypoints/content/common/utils/pages'
 import runDefault from '@/entrypoints/content/modules/week-number/handlers/default'
+import runOffice from '@/entrypoints/content/modules/week-number/handlers/office'
 import runPlayerDetail from '@/entrypoints/content/modules/week-number/handlers/player-detail'
 import runStadiumUsage from '@/entrypoints/content/modules/week-number/handlers/stadium-usage'
 import metadata from '@/entrypoints/content/modules/week-number/metadata'
@@ -22,6 +23,7 @@ const weekNumber: Module = {
     [pages.playerDetail.youth.own, runPlayerDetail],
     [pages.playerDetail.youth.other, runPlayerDetail],
     [pages.stadiumUsage, runStadiumUsage],
+    [pages.office, runOffice],
   ]),
 }
 


### PR DESCRIPTION
Closes #18

## Description

Both the denomination and week-number modules failed to run correctly on the pre-match and office pages because those pages use web components that render asynchronously.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works (or tests already exist)
- [x] I have tested my changes in Firefox
- [ ] I have tested my changes in a Chromium-based browser
- [ ] I have made corresponding changes to the documentation